### PR TITLE
1.0.1

### DIFF
--- a/Sources/CSVCodable/ExportManager.swift
+++ b/Sources/CSVCodable/ExportManager.swift
@@ -76,7 +76,10 @@ public class ExportManager {
             
             let values = encodedDic.map { objectDic in
                 objectDic
-                    .map { String(describing: $0.value) }
+                    .map { String(describing: $0.value)
+                        .replacingOccurrences(of: "\n", with: "")
+                        .replacingOccurrences(of: configuration.delimiter, with: "")
+                    }
                     .joined(separator: configuration.delimiter)
             }
            


### PR DESCRIPTION
- Remove occurences of newLine or the configured delimiter from the encoded string -> otherwise columns are messed up